### PR TITLE
🎨 Palette: Render Markdown in CLI output

### DIFF
--- a/src/bub/channels/cli/renderer.py
+++ b/src/bub/channels/cli/renderer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
 
@@ -38,7 +39,7 @@ class CliRenderer:
     def assistant_output(self, text: str) -> None:
         if not text.strip():
             return
-        self.console.print(Panel(text, title="Assistant", border_style="blue"))
+        self.console.print(Panel(Markdown(text), title="Assistant", border_style="blue"))
 
     def error(self, text: str) -> None:
         if not text.strip():


### PR DESCRIPTION
💡 **What:** 
Updated the `assistant_output` renderer in `src/bub/channels/cli/renderer.py` to parse and render text as Markdown using `rich.markdown.Markdown`.

🎯 **Why:** 
LLM/Assistant outputs typically contain Markdown formatting (bolding, lists, code blocks, etc.). Displaying this raw text in the terminal reduces readability. By natively parsing the Markdown string before passing it to the `rich` `Panel`, the terminal interface becomes much more visually pleasant, structured, and readable.

📸 **Before/After:**
- *Before:* `**Hello** \n - Item 1 \n - Item 2` was printed as raw text inside the CLI panel.
- *After:* `Hello` (in bold), followed by nicely formatted bullet points.

♿ **Accessibility:**
Provides a much clearer structure for reading terminal output by visually differentiating emphasis, lists, and code from regular text.

---
*PR created automatically by Jules for task [8497410156713924556](https://jules.google.com/task/8497410156713924556) started by @Andy963*