### PR TITLE
🎨 Palette: Render assistant output as Markdown in CLI

### DIFF
--- a/src/bub/channels/cli/renderer.py
+++ b/src/bub/channels/cli/renderer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.text import Text
 
@@ -38,7 +39,7 @@ class CliRenderer:
     def assistant_output(self, text: str) -> None:
         if not text.strip():
             return
-        self.console.print(Panel(text, title="Assistant", border_style="blue"))
+        self.console.print(Panel(Markdown(text), title="Assistant", border_style="blue"))
 
     def error(self, text: str) -> None:
         if not text.strip():


### PR DESCRIPTION
💡 **What:** The UX enhancement added is wrapping the assistant's output with `rich.markdown.Markdown` in the CLI renderer.
🎯 **Why:** The LLM assistant typically outputs Markdown formatted text (such as bolding, lists, and code blocks). Rendering it properly in the terminal makes the reading experience significantly more pleasant, intuitive, and readable compared to raw Markdown strings.
📸 **Before/After:** Before: raw text like `# Hello\n\n**bold**`. After: properly stylized, bolded, and colored text and code blocks in the terminal.
♿ **Accessibility:** Improves readability for all users by leveraging semantic terminal styling instead of requiring users to mentally parse Markdown syntax.

---
*PR created automatically by Jules for task [17033858246261629272](https://jules.google.com/task/17033858246261629272) started by @Andy963*